### PR TITLE
Update handlers in preparation for introducing ERS to drunc

### DIFF
--- a/python/erskafka/ERSKafkaLogHandler.py
+++ b/python/erskafka/ERSKafkaLogHandler.py
@@ -76,7 +76,10 @@ class ERSKafkaLogHandler(logging.Handler):
                 function_name = str(record.funcName),
                 process_id=record.process,
                 # thread_id= record.thread, (record.thread doesn't really work..)
+                #! Note to self, it seems that this doesnt work..
             )
         )
+        
+        self.publisher.producer.flush() #TODO: Formalise this..
         if not success:
             print(f'WARNING! Failed to publish: {record.msg} to Kafka')

--- a/python/erskafka/ERSKafkaLogHandler.py
+++ b/python/erskafka/ERSKafkaLogHandler.py
@@ -74,6 +74,8 @@ class ERSKafkaLogHandler(logging.Handler):
                 line_number = record.lineno,
                 file_name = str(record.pathname),
                 function_name = str(record.funcName),
+                process_id=record.process,
+                # thread_id= record.thread, (record.thread doesn't really work..)
             )
         )
         if not success:

--- a/python/erskafka/ERSKafkaLogHandler.py
+++ b/python/erskafka/ERSKafkaLogHandler.py
@@ -75,11 +75,11 @@ class ERSKafkaLogHandler(logging.Handler):
                 file_name = str(record.pathname),
                 function_name = str(record.funcName),
                 process_id=record.process,
-                # thread_id= record.thread, (record.thread doesn't really work..)
-                #! Note to self, it seems that this doesnt work..
+                thread_id=0 # TODO: have better way of handling this. It should come from drunc etc. 
             )
         )
         
-        self.publisher.producer.flush() #TODO: Formalise this..
+        #! publish returns a future, so a flush ensures the message is sent out
+        self.publisher.producer.flush()
         if not success:
             print(f'WARNING! Failed to publish: {record.msg} to Kafka')

--- a/python/erskafka/ERSPublisher.py
+++ b/python/erskafka/ERSPublisher.py
@@ -166,7 +166,8 @@ class ERSPublisher:
         issue_chain = ersissue.IssueChain(
             final=issue,
             session=os.getenv('DUNEDAQ_PARTITION', 'Unknown'),
-            application="python"
+            application="python",
+            module="TO FILL" #TODO I think we have to ask Marco about this
         )
 
         # Process the cause and add to issue_chain.causes, but not to issue.inheritance

--- a/python/erskafka/ERSPublisher.py
+++ b/python/erskafka/ERSPublisher.py
@@ -101,6 +101,7 @@ class ERSPublisher:
             host_name = socket.gethostname(),
             line_number = frame.f_lineno,
             user_name = os.getlogin(),
+            user_id = os.geteuid(),
             package_name = self.package_name,
             application_name = self.application_name,
         )

--- a/python/erskafka/ERSPublisher.py
+++ b/python/erskafka/ERSPublisher.py
@@ -166,8 +166,7 @@ class ERSPublisher:
         issue_chain = ersissue.IssueChain(
             final=issue,
             session=os.getenv('DUNEDAQ_PARTITION', 'Unknown'),
-            application="python",
-            module="TO FILL" #TODO I think we have to ask Marco about this
+            application="python"
         )
 
         # Process the cause and add to issue_chain.causes, but not to issue.inheritance


### PR DESCRIPTION
# Description

Fixes https://github.com/DUNE-DAQ/erskafka/issues/42

See https://github.com/DUNE-DAQ/drunc/issues/209 for details.

This repository contains the mechanisms to have an ers log handler. It mostly works, but minor changes are necessary for optimal performances.
- Process id was added
- user id was added

Something _incredibly_ important that was added here is the addition of `self.publisher.producer.flush()` (which took too long to debug). `self.publisher.publish` returns a `future` object so it must be flushed or awaited for the execution to finish before the function can be exited, or else it might not send  at all.



Things to be sorted thats beyond the scope of this PR:
- Thread ID needs to be further investigated as coming from the logger its quite large
- Module remains empty in Python processes.



A useful testing method is to be able to obtain the messages sent to the kafka broker without requiring a live listener. A test file called consumer.py is added that allows the retrieval of all messages that matches your username within some time window to check if messages have been sent properly. 

[consumer.py](https://github.com/user-attachments/files/23331117/consumer.py)




## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [x] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [x] Python tests pass if applicable (e.g. `python -m pytest`)
- [x] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

