### PR TITLE
Enable custom application names

### DIFF
--- a/python/erskafka/ERSKafkaLogHandler.py
+++ b/python/erskafka/ERSKafkaLogHandler.py
@@ -31,12 +31,14 @@ class ERSKafkaLogHandler(logging.Handler):
         session:str="Unknown",
         kafka_address:str="monkafka.cern.ch:30092",
         kafka_topic:str="ers_stream",
+        app_name:str | None = None,
     ):
         super().__init__()
         os.environ['DUNEDAQ_PARTITION'] = session
         self.session:str = session
         self.kafka_address:str = kafka_address
         self.kafka_topic:str = kafka_topic
+        self.app_name = app_name
 
         self.publisher = ERSPublisher(
             bootstrap = kafka_address,
@@ -70,7 +72,7 @@ class ERSKafkaLogHandler(logging.Handler):
             severity = ers_level.name,
             context_kwargs = dict(
                 package_name = str(record.module),
-                application_name =record.app_name if hasattr(record, "app_name") else str(record.name),
+                application_name = self.app_name if self.app_name else str(record.name),
                 line_number = record.lineno,
                 file_name = str(record.pathname),
                 function_name = str(record.funcName),

--- a/python/erskafka/ERSKafkaLogHandler.py
+++ b/python/erskafka/ERSKafkaLogHandler.py
@@ -70,7 +70,7 @@ class ERSKafkaLogHandler(logging.Handler):
             severity = ers_level.name,
             context_kwargs = dict(
                 package_name = str(record.module),
-                application_name = str(record.name),
+                application_name =record.app_name if hasattr(record, "app_name") else str(record.name),
                 line_number = record.lineno,
                 file_name = str(record.pathname),
                 function_name = str(record.funcName),


### PR DESCRIPTION
# Description

This PR is a dependency of 

DUNE-DAQ/drunc#776
DUNE-DAQ/daqpytools#54

Simply add the ability to customise the app name. Very straightforward




## Type of change

- [x] New feature or enhancement (non-breaking change which adds functionality)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

Nothing much to test here, just need to check that it works with the daqpytools thing. 

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

